### PR TITLE
Extract chapter name from hash

### DIFF
--- a/lib/renderer/contents_manifest_generator.rb
+++ b/lib/renderer/contents_manifest_generator.rb
@@ -19,7 +19,7 @@ module Playgroundbook
     end
 
     def manifest_contents(book_metadata)
-      chapters = book_metadata["chapters"].map { |c| "#{c}.playgroundchapter" }
+      chapters = book_metadata["chapters"].map { |c| "#{c["name"]}.playgroundchapter" }
       manifest_contents = {
         "Name" => book_metadata["name"],
         "ContentIdentifier" => book_metadata["identifier"],

--- a/lib/renderer/page_writer.rb
+++ b/lib/renderer/page_writer.rb
@@ -24,7 +24,7 @@ module Playgroundbook
           file.write({
             "Name" => page_name,
             "LiveViewMode" => chapter_info.has_key?("live_view_mode") ? chapter_info["live_view_mode"] : "HiddenByDefault",
-            "LiveViewEdgeToEdge" => chapter_info.has_key?(["edge_to_edge_live_view"]) ? chapter_info["edge_to_edge_live_view"] : true,
+            "LiveViewEdgeToEdge" => chapter_info.has_key?("edge_to_edge_live_view") ? chapter_info["edge_to_edge_live_view"] : true,
             "Version" => "1.0",
             "ContentVersion" => "1.0"
           }.to_plist)

--- a/spec/renderer/contents_manfiest_generator_spec.rb
+++ b/spec/renderer/contents_manfiest_generator_spec.rb
@@ -30,7 +30,7 @@ module Playgroundbook
       end
 
       it "has chapters specified" do
-        expect(get_manifest["Chapters"]).to eq(["{\"name\"=>\"test_chapter\"}.playgroundchapter"])
+        expect(get_manifest["Chapters"]).to eq(["test_chapter.playgroundchapter"])
       end
 
       it "has a ImageReference" do


### PR DESCRIPTION
I introduced a bug yesterday, which led to chapter names not being extracted from the hash resulting in chapter names in the `Manifest.plist` being `"{\"name\"=>\"test_chapter\"}.playgroundchapter"` instead of `test_chapter.plagroundchapter`.