### PR TITLE
Copy SPM Sources into top-level Sources for book

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Current Master
 
+- Adds basic support for Swift Package Manager dependencies. See [#50](https://github.com/playgroundbooks/playgroundbook/pull/50).
+
 # 0.5.0
 
 - Embeds images inside the local Playground when converting from markdown. See [#30](https://github.com/ashfurrow/playgroundbook/pull/30).

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Pages are divided by lines beginning with a quadruple slash, followed by that pa
 
 ### Limitations of Book Rendering
 
-Preamble (anything about the first `////` page) is put in its own file. That means declarations there need to be `public` to be visible within individual pages (even though when you're writing, everything is in one file). Additionally, the preamble is at the top-level and can't contain expressions. This would cause a compiler error in the Swift Playrounds iPad app:
+The preamble (anything about the first `////` page) is put in its own file. That means declarations there need to be `public` to be visible within individual pages (even though when you're writing, everything is in one file). Additionally, the preamble is at the top-level and can't contain expressions. This would cause a compiler error in the Swift Playrounds iPad app:
 
 ```swift
 public let layout = UICollectionViewFlowLayout()
@@ -101,6 +101,12 @@ public var layout: UICollectionViewFlowLayout = {
 It's awkward; if you have suggestions, open an issue :+1:
 
 Sharing resources is only available book-wide and not specific to chapters. Sharing code outside the preamble isn't supported yet.
+
+#### Using Swift Package Manager Dependencies
+
+If you place a `Package.swift` file next to your playgroundbook manifest used for rendering a book and run `swift package fetch` to fetch the corresponding sources into `Packages/`, these will be copied into the playground book's top-level `Sources` when building and available in the finished book.
+These source files will also be copied into the original playground for each chapter to make these available for use in Xcode.
+Please note that this will work best with SPM packages containing pure Swift.
 
 Playground books support a rich set of awesome features to make learning how to code really easy, and this tool uses almost none of them. It sacrifices this experience for the sake of being able to easily write the books on your Mac.
 

--- a/lib/playgroundbook.rb
+++ b/lib/playgroundbook.rb
@@ -7,4 +7,5 @@ module Playgroundbook
   ContentsSwiftFileName = "Contents.swift".freeze
   ResourcesDirectoryName = "Resources".freeze
   PagesDirectoryName = "Pages".freeze
+  SourcesDirectoryName = "Sources".freeze
 end

--- a/lib/renderer/playgroundbook_renderer.rb
+++ b/lib/renderer/playgroundbook_renderer.rb
@@ -56,6 +56,10 @@ module Playgroundbook
         Dir.mkdir(ContentsDirectoryName) unless Dir.exist?(ContentsDirectoryName)
         Dir.chdir(ContentsDirectoryName) do
           Dir.mkdir(ResourcesDirectoryName) unless Dir.exist?(ResourcesDirectoryName) # Always create a Resources dir, even if empty.
+          Dir.mkdir(SourcesDirectoryName) unless Dir.exist?(SourcesDirectoryName)
+          Dir.glob("../../Packages/**/Sources/*.swift").each do |file|
+            FileUtils.cp(file, SourcesDirectoryName)
+          end
           resources_dir = book["resources"]
           unless resources_dir.nil? || resources_dir.empty?
             @ui.puts "Copying resource directory (#{resources_dir.green}) contents."

--- a/lib/renderer/playgroundbook_renderer.rb
+++ b/lib/renderer/playgroundbook_renderer.rb
@@ -51,6 +51,13 @@ module Playgroundbook
       end
       parsed_chapters = book_chapter_contents.map { |c| page_parser.parse_chapter_pages(c) }
 
+      book["chapters"].map do |chapter|
+        Dir.glob("Packages/**/Sources/*.swift").each do |file|
+           playground_sources_path = "#{chapter['name']}.playground/Sources"
+           Dir.mkdir(playground_sources_path) unless Dir.exist?(playground_sources_path)
+           FileUtils.cp(file, playground_sources_path)
+         end
+      end
       Dir.mkdir(book_dir_name) unless Dir.exist?(book_dir_name)
       Dir.chdir(book_dir_name) do
         Dir.mkdir(ContentsDirectoryName) unless Dir.exist?(ContentsDirectoryName)


### PR DESCRIPTION
This could be a very barebones solution for https://github.com/playgroundbooks/playgroundbook/issues/21

Assuming a `Package.swift` file specifying libraries to be used these can be copied into the `.playgroundbook` after being fetched by SPM.

It seems to me that SPM is the most straightforward option for including libraries in a playground book as well as having the least caveats associated with it.

A couple of tweaks to make this more useful could be:

- [x] Copy into source playgrounds to support work in Xcode
- [ ] Allow more granular destinations (chapter or page) to be specified in YAML
